### PR TITLE
Add minimal snapshot handling support

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -841,7 +841,7 @@ cdef class ZFSDataset(object):
         if libzfs.zfs_destroy(self._handle, True) != 0:
             raise ZFSException(self.root.errno, self.root.errstr)
 
-    def destroy_snaps(self, name):
+    def destroy_snapshot(self, name):
         if libzfs.zfs_destroy_snaps(self._handle, name, True) !=0:
             raise ZFSException(self.root.errno, self.root.errstr)
 

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -841,6 +841,10 @@ cdef class ZFSDataset(object):
         if libzfs.zfs_destroy(self._handle, True) != 0:
             raise ZFSException(self.root.errno, self.root.errstr)
 
+    def destroy_snaps(self, name):
+        if libzfs.zfs_destroy_snaps(self._handle, name, True) !=0:
+            raise ZFSException(self.root.errno, self.root.errstr)
+
     def mount(self):
         if libzfs.zfs_mount(self._handle, NULL, 0) != 0:
             raise ZFSException(self.root.errno, self.root.errstr)
@@ -856,6 +860,15 @@ cdef class ZFSDataset(object):
 
     def send(self, fd):
         if libzfs.zfs_send_one(self._handle, NULL, fd, 0) != 0:
+            raise ZFSException(self.root.errno, self.root.errstr)
+
+    def snapshot(self, name, fsopts):
+        cdef uintptr_t cfsopts = fsopts.handle()
+        if libzfs.zfs_snapshot(
+            <libzfs.libzfs_handle_t*>self.root.handle(),
+            name,
+            True,
+            <nvpair.nvlist_t*>cfsopts) != 0:
             raise ZFSException(self.root.errno, self.root.errstr)
 
     def receive(self, fd, force=False, nomount=False):


### PR DESCRIPTION
Create snapshot example:
```python
>>> import libzfs
>>> import nvpair
>>> zfs = libzfs.ZFS()
>>> ds = zfs.get_dataset('zroot/ROOT/default')
>>> nv = nvpair.NVList()
>>> ds.snapshot('zroot/ROOT/default@jojo', nv)
```

Destroy snapshot example:
```python
>>> import libzfs
>>> zfs = libzfs.ZFS()
>>> ds = zfs.get_dataset('zroot/ROOT/default')
>>> ds.destroy_snapshot('jojo')
```